### PR TITLE
Fix typo in an internal dot import

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/Exotel-Org/aerospike-client-g/utils/buffer"
+	. "github.com/Exotel-Org/aerospike-client-go/utils/buffer"
 	as "github.com/Exotel-Org/aerospike-client-go"
 	. "github.com/Exotel-Org/aerospike-client-go/types"
 


### PR DESCRIPTION
This import is breaking building certain internal services (when building from scratch). I believe this is a mistake/typo and not intentional. It was introduced in [this](https://github.com/Exotel-Org/aerospike-client-go/commit/71b5e272c57c6e5666129b2c99bd82354ecbffcd#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3R26) commit.

```
go: finding module for package github.com/Exotel-Org/aerospike-client-g/utils/buffer
<redacted>/configmanager imports
	<redacted>/lib/cache/go imports
	github.com/Exotel-Org/aerospike-client-go tested by
	github.com/Exotel-Org/aerospike-client-go.test imports
	github.com/Exotel-Org/aerospike-client-g/utils/buffer: cannot find module providing package github.com/Exotel-Org/aerospike-client-g/utils/buffer: module github.com/Exotel-Org/aerospike-client-g/utils/buffer: git ls-remote -q origin in /home/akshay/.asdf/installs/golang/1.16.4/packages/pkg/mod/cache/vcs/5b178946265d0fa6da944f98207cd354c4651cec96718b3545199d5daca38ecd: exit status 128:
	ERROR: Repository not found.
	fatal: Could not read from remote repository.
	
	Please make sure you have the correct access rights
	and the repository exists.
```
